### PR TITLE
Update cloudify.markdown

### DIFF
--- a/documentation/cloudify2_driver/cloudify.markdown
+++ b/documentation/cloudify2_driver/cloudify.markdown
@@ -30,9 +30,13 @@ In order to handle Cloudify lifecycle events, and to emit our own events, we nee
 {%endhighlight%}
 * Right after that line, add the following snippet
 {%highlight sh%}
-	if [ "$GSA_MODE" = "lus" ]; then
-		cat <(crontab -l) <(echo "@reboot export LUS_IP_ADDRESS=$LUS_IP_ADDRESS; chmod +x ${WORKING_HOME_DIRECTORY}/events/bin/gsDeployEventsWar.sh; nohup ${WORKING_HOME_DIRECTORY}/events/bin/gsDeployEventsWar.sh") | crontab -
-	fi
+    if [ "$GSA_MODE" = "lus" ]; then
+        exportJavaHome="" 
+        if [ ! -z ${JAVA_HOME} ]; then
+            exportJavaHome="export JAVA_HOME=${JAVA_HOME}; " 
+        fi
+        cat <(crontab -l) <(echo "@reboot ${exportJavaHome} export LUS_IP_ADDRESS=$LUS_IP_ADDRESS; chmod +x ${WORKING_HOME_DIRECTORY}/events/bin/gsDeployEventsWar.sh; nohup ${WORKING_HOME_DIRECTORY}/events/bin/gsDeployEventsWar.sh") | crontab -
+    fi
 {%endhighlight%}
 
 * Locate the line


### PR DESCRIPTION
Modification pour prendr en compte le cas où java n'est pas embarqué sur la node.
Note : gsDeployEventsWar.sh pourrait il  'sourcer' ~/gigaspaces/bin/setenv.sh et ainsi obtenir toute les variable d'env ?